### PR TITLE
fix CVE-2018-3728

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -405,7 +405,7 @@
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "5.0.3"
             }
         },
         "bootstrap": {
@@ -1861,7 +1861,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "hoek": "2.16.3"
+                        "hoek": "5.0.3"
                     }
                 },
                 "brace-expansion": {


### PR DESCRIPTION
Correction d'une faille découverte dans le module [hoek](https://github.com/hapijs/hoek) qui est utilisé comme utilitaire Node pour la gestion d'un Framework NodeJS